### PR TITLE
.npmignoreを追加

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+tsconfig.json
+src/
+*.map


### PR DESCRIPTION
実際にインストールして利用する際に不要なファイル/ディレクトリを `.npmignore` に追加